### PR TITLE
Ensure python3 compatibility / Make usage of internal logger

### DIFF
--- a/octoprint_themeify/__init__.py
+++ b/octoprint_themeify/__init__.py
@@ -10,7 +10,7 @@ class ThemeifyPlugin(octoprint.plugin.StartupPlugin,
                      octoprint.plugin.TemplatePlugin):
 
     def on_after_startup(self):
-        print "Themeify initialized."
+        self._logger.info("Themeify initialized.")
 
     def get_assets(self):
         return dict(


### PR DESCRIPTION
Giving the facts :

- print is now a function in python3
- octoprint provide logger instance for third party plugins
- octoprint is on his way to python3 migration

It should be a good idea to apply this PR soon

Thanks for your work though