### PR TITLE
some tweaks and improvements to material_ui_light.less

### DIFF
--- a/octoprint_themeify/static/less/material-ui-light/material_ui_light.less
+++ b/octoprint_themeify/static/less/material-ui-light/material_ui_light.less
@@ -138,9 +138,11 @@
         box-shadow: 0 30px 50px -30px rgba(0, 0, 0, 0.76) !important;
         border: 0 !important;
     }
-    .nav-list>.active>a, .nav-list>.active>a:hover {
-        background-color: #2196F3;
-        color: #ffffff;
+    .nav-list, .nav-pills {
+        >.active>a, >.active>a:hover {
+            background-color: #2196F3;
+            color: #ffffff;
+        }
     }
     .modal-footer {
         border: 0;

--- a/octoprint_themeify/static/less/material-ui-light/material_ui_light.less
+++ b/octoprint_themeify/static/less/material-ui-light/material_ui_light.less
@@ -27,10 +27,6 @@
     .btn-group .btn:first-of-type:last-of-type {
         width: 100%;
     }
-    .input-prepend .btn:not(:last-child), 
-    .input-append .add-on:not(:last-child), 
-    .input-append .btn:not(:last-child), 
-    .btn-group .btn:not(:last-of-type) 
     .btn, .btn:focus, .btn:hover {
         transition: filter 0.2s ease, background-color 0.2s ease;
     }

--- a/octoprint_themeify/static/less/material-ui-light/material_ui_light.less
+++ b/octoprint_themeify/static/less/material-ui-light/material_ui_light.less
@@ -4,6 +4,33 @@
         filter: brightness(1.0);
         border-radius: 3px;
     }
+    .input-prepend, .input-append {
+        .add-on:not(:last-child), .btn:not(:last-child) {
+            border-top-right-radius: 0;
+            border-bottom-right-radius: 0;
+        }
+    }
+    .btn-group .btn:not(:last-of-type) {
+        border-top-right-radius: 0;
+        border-bottom-right-radius: 0;
+    }
+    .input-prepend, .input-append {
+        .add-on:not(:first-child), .btn:not(:first-child) {
+            border-top-left-radius: 0;
+            border-bottom-left-radius: 0;
+        }
+    }
+    .btn-group .btn:not(:first-of-type) {
+        border-top-left-radius: 0;
+        border-bottom-left-radius: 0;
+    }
+    .btn-group .btn:first-of-type:last-of-type {
+        width: 100%;
+    }
+    .input-prepend .btn:not(:last-child), 
+    .input-append .add-on:not(:last-child), 
+    .input-append .btn:not(:last-child), 
+    .btn-group .btn:not(:last-of-type) 
     .btn, .btn:focus, .btn:hover {
         transition: filter 0.2s ease, background-color 0.2s ease;
     }
@@ -71,7 +98,8 @@
         box-shadow: none !important;
         border-color: #2196F3;
     }
-    .slider .slider-track {
+    .slider .slider-track,
+    #settings_dialog .tab-content {
         box-shadow: none;
     }
     .slider .slider-selection {
@@ -95,7 +123,7 @@
     }
     #navbar .navbar-inner {
         background-image: none !important;
-        box-shadow: 0px 0px 15px black !important;
+        box-shadow: 0 4px 6px -4px rgba(0, 0, 0, 0.47) !important;
         border: none !important;
     }
     #navbar .navbar-inner .nav>li>a:hover {
@@ -116,6 +144,7 @@
     }
     .nav-list>.active>a, .nav-list>.active>a:hover {
         background-color: #2196F3;
+        color: #ffffff;
     }
     .modal-footer {
         border: 0;


### PR DESCRIPTION
I just installed this plugin and fell in love with the theme, but immediately noticed some necessary tweaks, so here they are :) Hope this helps. :)

- use the same drop shadows everywhere
- ensure that the border radius change to buttons doesn't break the merged-button-look of input-prepend, input-append and btn-group 
- don't add a drop shadow to the scrolling container of settings panes
- ensure that the "select tool" dropdown button on the control tab is full-width so the btn-group drop shadow doesn't extend over its boundaries
- ensure that color:inherit; meant to affect tab text color doesn't lead to the active element in the settings nav being displayed as low-contrast dark grey text on a blue background