### PR TITLE
Fix Discord theme hover/active tab misalignment

### DIFF
--- a/octoprint_themeify/static/less/discorded/discorded.less
+++ b/octoprint_themeify/static/less/discorded/discorded.less
@@ -48,7 +48,7 @@
         .nav-tabs>.active>a, .nav-tabs>.active>a:hover {
             background-color: @notquiteBlack;
             color: #fff;
-            border: none;
+            border-bottom-color: transparent;
         }
         .nav-pills>.active>a, .nav-pills>.active>a:hover {
             background-color: @blurple;
@@ -56,7 +56,7 @@
 
         .nav-tabs>li>a:hover {
             background-color: lighten(@notquiteBlack, 10);
-            border: none;
+            border-bottom-color: transparent;
         }
         
         h1, h2, h3, h4 {
@@ -232,6 +232,7 @@
 
             & .brand, .nav > li > a {
                 color: #fff;
+                border-bottom: 1px solid transparent;
                 & .caret {
 					border-top-color: #fff;
 					border-bottom-color: #fff;


### PR DESCRIPTION
When you hover or activate a tab or navbar menu, the border changes and the tabs get misaligned:

Before:
![themeify-css-before](https://user-images.githubusercontent.com/2470905/94523938-d5464900-0229-11eb-8955-1f48991ae1ae.gif)
After:
![themeify-css-after](https://user-images.githubusercontent.com/2470905/94523946-d7a8a300-0229-11eb-93fe-9a16ecda3738.gif)
